### PR TITLE
[Spike] ni layer seungmin

### DIFF
--- a/src/main/java/com/github/software_development_methodology_study/Main.java
+++ b/src/main/java/com/github/software_development_methodology_study/Main.java
@@ -29,10 +29,7 @@ public class Main {
 
 
 
-        List<PcapNetworkInterface> interfaces1 = Pcaps.findAllDevs();
-        for (PcapNetworkInterface nif : interfaces1) {
-            System.out.println(nif.getName() + " : " + nif.getDescription());
-        }
+
         // NIF 가져오기
 //        PcapNetworkInterface nif = Pcaps.getDevByName("\\Device\\NPF_{6F60B71D-1C9E-4C66-97E6-FBA81EBD2E6E}");
         PcapNetworkInterface nif = Pcaps.getDevByName("\\Device\\NPF_{83D8ABE6-6CA7-45BA-A361-335258177916}");
@@ -45,10 +42,13 @@ public class Main {
         // 캡처 핸들러 열기
         PcapHandle handle = nif.openLive(65536, PcapNetworkInterface.PromiscuousMode.PROMISCUOUS, 10000);
 
-        // 패킷 캡처
         Packet packet = handle.getNextPacketEx();
-        System.out.println(packet);
-
+        // 패킷 캡처
+        int i = 100;
+        while (i-->1) {
+            packet = handle.getNextPacketEx();
+            System.out.println(packet);
+        }
 
 // 바이트 배열 형태의 로우 패킷 데이터
         byte[] rawData = packet.getRawData();

--- a/src/main/java/com/github/software_development_methodology_study/core/layer/NetworkInterfaceLayer.java
+++ b/src/main/java/com/github/software_development_methodology_study/core/layer/NetworkInterfaceLayer.java
@@ -2,12 +2,16 @@ package com.github.software_development_methodology_study.core.layer;
 
 import com.github.software_development_methodology_study.core.data.chunk.Chunk;
 import com.github.software_development_methodology_study.core.data.chunk.header.EmptyHeader;
+import com.github.software_development_methodology_study.core.data.chunk.payload.Payload;
+import org.pcap4j.core.*;
 
-public class NetworkInterfaceLayer extends Layer<EmptyHeader> implements Runnable {
+import java.util.List;
 
-    @Override
-    public void run() {
+public class NetworkInterfaceLayer extends Layer<EmptyHeader> {
+    private List<PcapHandle> pcapHandleList;
 
+    public NetworkInterfaceLayer() throws PcapNativeException {
+        pcapHandleList = getNICHandleList();
     }
 
     @Override
@@ -15,10 +19,76 @@ public class NetworkInterfaceLayer extends Layer<EmptyHeader> implements Runnabl
 
     }
 
+    // Byte를 쓰면 unboxing 작업은 어디선가 해야 됨
+    // 일단 모든 nic에서 패킷 발송하도록 함
     @Override
     public void send(Chunk chunk) {
+        Byte[] payload = chunk.getPayload().getBytes();
+        Byte[] header = chunk.getHeader().getBytes();
 
+        Byte[] packet = new Byte[header.length + payload.length];
+        System.arraycopy(header, 0, packet, 0, header.length);
+        System.arraycopy(payload, 0, packet, header.length, payload.length);
+
+        byte[] rawPacket = new byte[packet.length];
+        for(int i = 0; i < packet.length; i++)
+            rawPacket[i] = packet[i];
+
+        pcapHandleList.stream().parallel().forEach(t -> {
+            try {
+                t.sendPacket(rawPacket);
+            } catch (NotOpenException | PcapNativeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public void startNICThread(PcapHandle handle) {
+        Thread thread = new Thread(() -> {
+            try {
+                handle.loop(-1, new RawPacketListener() {
+                    @Override
+                    public void gotPacket(byte[] packet) {
+                        EmptyHeader emptyHeader = new EmptyHeader();
+                        Chunk<EmptyHeader> chunk = new Chunk<>();
+                        chunk.setHeader(emptyHeader);
+//                        chunk.setPayload(new Payload(packet));  // Byte unboxing 귀찮아서 일단 주석처리..
+
+                        // 타입 불일치 문제
+                        // receive 메서드로 보내고 receive 메서드에서 upper를 호출할까?
+//                        upperLayer.send(chunk);
+                    }
+                });
+            } catch (PcapNativeException | NotOpenException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+        });
+        thread.start();
+    }
+
+    // 루프를 명시적으로 종료하지 않으면 계속 돌 수 있다고 함
+    public void stopNICThreads() throws PcapNativeException {
+        pcapHandleList.forEach(t -> {
+            try {
+                t.breakLoop();
+                t.close();
+            } catch (NotOpenException e) {
+                System.err.println("이미 닫힌 핸들입니다." + e);
+            }
+        });
     }
 
 
+
+    private List<PcapHandle> getNICHandleList() throws PcapNativeException {
+        List<PcapNetworkInterface> interfaces = Pcaps.findAllDevs();
+        return interfaces.stream().map(t -> {
+            try {
+                return t.openLive(65535, PcapNetworkInterface.PromiscuousMode.PROMISCUOUS, 10);
+            } catch (PcapNativeException e) {
+                throw new RuntimeException(e);
+            }
+        }).toList();
+    }
 }


### PR DESCRIPTION
### 🧪 Spike 목표
> #27 NI-Layer 구현

### 🔨 작업 내용
#### 각 NIC 마다 패킵 캡처, 발송
- NIC 목록 조회 후 각 NIC마다 loop 실행

#### NIC breakloop 추가


### 🧹 기타
#### send 메서드 관심사 분리
- send 메서드 내 Byte[] -> byte[] unboxing 부분 분리 예정

#### 예외 처리 통일 예정
#### Byte[] -> byte[] 구현 예정
#### upperLayer.send() 구현예정


