### PR TITLE
[Refactor] layer receive메서드 매개변수 수정

### DIFF
--- a/src/main/java/com/github/software_development_methodology_study/core/layer/GUILayer.java
+++ b/src/main/java/com/github/software_development_methodology_study/core/layer/GUILayer.java
@@ -135,7 +135,7 @@ public class GUILayer extends Layer<EmptyHeader> {
     }
 
     @Override
-    public boolean receive(Chunk<EmptyHeader> chunk, PcapNetworkInterface nic) {
+    public boolean receive(Chunk<Header> chunk, PcapNetworkInterface nic) {
         String message = ByteArrayToString(chunk.getPayload().getBytes());
         generateChatLogMessage(message, ChatLogMode.RECEIVE);
         return true;

--- a/src/main/java/com/github/software_development_methodology_study/core/layer/Layer.java
+++ b/src/main/java/com/github/software_development_methodology_study/core/layer/Layer.java
@@ -40,7 +40,7 @@ public abstract class Layer<T extends Header> {
      * @param chunk
      * @param nic
      */
-    public abstract boolean receive(Chunk<EmptyHeader> chunk, PcapNetworkInterface nic);
+    public abstract boolean receive(Chunk<Header> chunk, PcapNetworkInterface nic);
 
     /**
      * 상위 레이어에서 Chunk를 전달받아 처리하는 메서드


### PR DESCRIPTION


<!-------------------------- Refactor -------------------------->
<!-- Title: [Refactor] description -->
<!-- Label:  -->
## 🔧 Refactoring PR

### 📌 목적
<!-- 어떤 의도로 리팩토링을 진행했는지 작성 -->
- receive 메서드 매개변수 Chunk의 제네릭 타입 변경
- 추상 Header로 정의하고, 다양한 구체 Header로 확장하기 위함

---

### 🧩 변경 요약
<!-- 주요 변경 사항 요약 (기능 변경 없어야 함) -->
- Layer, GUILayer 클래스의 receive 메서드 매겨변수 
- Chunk<EmptyHeader> -> Chunk<Header>

---

### ✅ 영향도
- [x] 기존 동작과 동일 

---

### 📝 기타 참고 사항
- 기존 GUILayer 클래스의 receive 메서드 내 Header의 구체 클래스 메서드 사용시 테스트 필요
